### PR TITLE
create: requirements-detail page

### DIFF
--- a/app/static/css/base/base.css
+++ b/app/static/css/base/base.css
@@ -7,6 +7,27 @@ body {
   gap: 40px;
 }
 
+h1, h2, h3, h4, h5, h6, p {
+  margin: 0;
+}
+
+input[type=number], input[type=text] {
+  border: none;
+}
+
+input[type=number], input[type=text] {
+  padding: 0;
+}
+
+input, textarea {
+  outline: none;
+}
+
+input[type="number"]::-webkit-outer-spin-button, 
+input[type="number"]::-webkit-inner-spin-button { 
+  -webkit-appearance: none; 
+}
+
 ul {
   margin: 0;
   padding: 0;

--- a/app/static/css/components/header.css
+++ b/app/static/css/components/header.css
@@ -7,6 +7,7 @@
   box-shadow: 0 4px 4px 0 rgba(0,0,0,0.25);
   position: sticky;
   top: 0;
+  z-index: 999;
 }
 
 .header--wrap {

--- a/app/static/css/components/requirements_sheet.css
+++ b/app/static/css/components/requirements_sheet.css
@@ -1,0 +1,105 @@
+.requirements {
+  background-color: #ffffff;
+  border-radius: 20px;
+  width: 68%;
+  padding: 16px;
+}
+
+.requirements--titles {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.requirements--titles__title {
+  font-size: 40px;
+}
+
+.requirements--titles__contents {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.requirements--titles__contents-title {
+  font-size: 20px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.requirements--titles__contents-border {
+  width: 100%;
+  height: 4px;
+  background-color: #51A243;
+}
+
+.requirements--titles__contents-main {
+  height: 100%;
+  font-size: 24px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.requirements--contents {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.requirements--contents__requirement {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.requirements--contents__title {
+  font-size: 32px;
+}
+
+.requirements--contents__content {
+  margin-left: 32px;
+  font-size: 24px;
+}
+
+.requirements--contents__content-tech {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.requirements--contents__content-tech-icon {
+  background-color: #9AB292;
+  width: 80px;
+  height: 80px;
+}
+
+.requirements--contents__articles {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.requirements--contents__article-list {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+}
+
+.requirements--contents__article {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.requirements--contents__article-img {
+  background-color: #9AB292;
+  width: 200px;
+  height: 120px;
+}
+
+.requirements--contents__article-text {
+  font-size: 20px;
+}

--- a/app/static/css/components/three_levels.css
+++ b/app/static/css/components/three_levels.css
@@ -1,0 +1,45 @@
+.three-levels--button {
+  display: flex;
+  gap: 4px;
+}
+
+.three-levels--button input[type=radio] {
+  display: none;
+}
+
+.three-levels--button__text {
+  border: 1px solid #000000;
+  border-radius: 23px;
+  font-weight: bold;
+  padding: 8px;
+}
+
+.three-levels--button__green {
+  border: 2px solid #51A243;
+  color: #51A243;
+}
+
+:checked + .three-levels--button__green {
+  background-color: #51A243;
+  color: #ffffff;
+}
+
+.three-levels--button__blue {
+  border: 2px solid #0096FF;
+  color: #0096FF;
+}
+
+:checked + .three-levels--button__blue {
+  background-color: #0096FF;
+  color: #ffffff;
+}
+
+.three-levels--button__red {
+  border: 2px solid #EE6720;
+  color: #EE6720;
+}
+
+:checked + .three-levels--button__red {
+  background-color: #EE6720;
+  color: #ffffff;
+}

--- a/app/static/css/requirements/detail.css
+++ b/app/static/css/requirements/detail.css
@@ -1,0 +1,118 @@
+.body--wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 2%;
+  margin-bottom: 152px;
+}
+
+.requirements-form {
+  background-color: #ffffff;
+  border-radius: 20px;
+  width: 30%;
+  height: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.requirements-form-title {
+  font-size: 28px;
+}
+
+.requirements-form--sub-title {
+  font-size: 24px;
+}
+
+.requirements-form--column {
+  display: flex;
+  flex-direction: column;
+  align-items: self-start;
+}
+
+.requirements-form input[type=number], 
+.requirements-form input[type=text] {
+  border-bottom: 2px solid #9AB292;
+}
+
+.requirements-form--input-text {
+  height: 28px;
+  width: 180px;
+  font-size: 20px;
+  color: #9AB292;
+}
+
+.requirements-form--input-number {
+  width: 80px;
+}
+
+.requirements-form--input-text::placeholder {
+  font-size: 20px;
+  color: #9AB292;
+}
+
+.requirements-form--text {
+  display: flex;
+  font-size: 20px;
+  font-weight: bold;
+}
+.requirements-form--text input[type=radio] {
+  white-space: nowrap;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  border: 0;
+  padding: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%); 
+  margin: -1px;
+}
+
+.requirements-form--text label {
+  position: relative;
+  cursor: pointer;
+  padding-left: 30px;
+}
+
+.requirements-form--text label::before,
+.requirements-form--text label::after {
+  content: "";
+  display: block; 
+  border-radius: 50%;
+  position: absolute;
+  transform: translateY(-50%);
+  top: 50%;
+}
+
+.requirements-form--text label::before {
+  background-color: #fff;
+  border: 1px solid #3F4A3C;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  left: 5px;
+}
+
+.requirements-form--text label::after {
+  background-color: #3F4A3C;
+  border-radius: 50%;
+  opacity: 0;
+  width: 16px;
+  height: 16px;
+  left: 8px
+}
+
+.requirements-form--text input:checked + label::after {
+  opacity: 1;
+}
+
+.submit-button {
+  width: 100%;
+  padding: 8px;
+  background-color: #51A243;
+  color: #ffffff;
+  border: none;
+  border-radius: 28px;
+  font-size: 24px;
+  font-weight: bold;
+}

--- a/app/templates/components/requirements_sheet.html
+++ b/app/templates/components/requirements_sheet.html
@@ -1,0 +1,67 @@
+<div class="requirements">
+  <div class="requirements--titles">
+    <h2 class="requirements--titles__title">{タイトル}</h2>
+    <div class="requirements--titles__contents">
+      <div class="requirements--titles__contents-title">{応募数}</div>
+      <div class="requirements--titles__contents-border"></div>
+      <div class="requirements--titles__contents-main">○人</div>
+    </div>
+  </div>
+  <div class="requirements--contents">
+    <div class="requirements--contents__requirement">
+      <h3 class="requirements--contents__title">要件</h3>
+      <p class="requirements--contents__content">{}</p>
+    </div>
+    <div>
+      <h3 class="requirements--contents__title">使用技術</h3>
+      <div class="requirements--contents__content">
+        <h4>フロントエンド</h4>
+        <div class="requirements--contents__content-tech">
+          <div class="requirements--contents__content-tech-icon">{}</div>
+        </div>
+      </div>
+      <div class="requirements--contents__content">
+        <h4>バックエンド</h4>
+        <div class="requirements--contents__content-tech">
+          <div class="requirements--contents__content-tech-icon">{}</div>
+        </div>
+      </div>
+      <div class="requirements--contents__content">
+        <h4>インフラ</h4>
+        <div class="requirements--contents__content-tech">
+          <div class="requirements--contents__content-tech-icon">{}</div>
+        </div>
+      </div>
+    </div>
+    <div class="requirements--contents__articles">
+      <h3 class="requirements--contents__title">関連記事</h3>
+      <div class="requirements--contents__content">
+        <h4>フロントエンド</h4>
+        <div class="requirements--contents__article-list">
+          <a href="#" class="requirements--contents__article">
+            <div class="requirements--contents__article-img">{画像}</div>
+            <div class="requirements--contents__article-text">{テキスト}</div>
+          </a>
+        </div>
+      </div>
+      <div class="requirements--contents__content">
+        <h4>バックエンド</h4>
+        <div class="requirements--contents__article-list">
+          <a href="#" class="requirements--contents__article">
+            <div class="requirements--contents__article-img">{画像}</div>
+            <div class="requirements--contents__article-text">{テキスト}</div>
+          </a>
+        </div>
+      </div>
+      <div class="requirements--contents__content">
+        <h4>インフラ</h4>
+        <div class="requirements--contents__article-list">
+          <a href="#" class="requirements--contents__article">
+            <div class="requirements--contents__article-img">{画像}</div>
+            <div class="requirements--contents__article-text">{テキスト}</div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/templates/requirements/detail.html
+++ b/app/templates/requirements/detail.html
@@ -1,7 +1,55 @@
-{% extends 'base/base.html' %}
+{% extends 'base/base_user.html' %}
 {% block head %}
-  <title>詳細</title>
+  <title>要件詳細</title>
+  {% load static %}
+  <link rel="stylesheet" href="{% static 'css/components/header.css' %}" />
+  <link rel="stylesheet" href="{% static 'css/components/requirements_sheet.css' %}" />
+  <link rel="stylesheet" href="{% static 'css/components/three_levels.css' %}" />
+  <link rel="stylesheet" href="{% static 'css/requirements/detail.css' %}" />
 {% endblock %}
 {% block body %}
-  <div>ここだよん</div>
+  {% include 'components/header.html' %}
+  <div class="body--wrap">
+    {% include 'components/requirements_sheet.html' %}
+    <form class="requirements-form" action="#" method="post">
+      <h3 class="requirements-form-title">応募フォーム</h3>
+      <div>
+        <h4 class="requirements-form--sub-title">希望ポジション</h4>
+        <div class="three-levels--button">
+          <input type="radio" name="position" value="front" id="front" /><label for="front" class="three-levels--button__text three-levels--button__green">フロント</label>
+          <input type="radio" name="position" value="back" id="back" /><label for="back" class="three-levels--button__text three-levels--button__blue">バック</label>
+          <input type="radio" name="position" value="infra" id="infra" /><label for="infra" class="three-levels--button__text three-levels--button__red">インフラ</label>
+        </div>
+      </div>
+      <div>
+        <h4 class="requirements-form--sub-title">現在のステップ数</h4>
+        <input type="number" min="0", max="500" placeholder="例：150" class="requirements-form--input-text requirements-form--input-number" />
+      </div>
+      <div class="requirements-form--column">
+        <h4 class="requirements-form--sub-title">週のコミット可能時間</h4>
+        <div class="requirements-form--text"><input type="radio" name="commit" value="10h" id="10h" /><label for="10h">10h</label></div>
+        <div class="requirements-form--text"><input type="radio" name="commit" value="15h" id="15h" /><label for="15h">15h</label></div>
+        <div class="requirements-form--text"><input type="radio" name="commit" value="20h" id="20h" /><label for="20h">20h</label></div>
+        <div class="requirements-form--text"><input type="radio" name="commit" value="20h~" id="20h~" /><label for="20h~">20h~</label></div>
+      </div>
+      <div>
+        <h4 class="requirements-form--sub-title">稼働想定日時</h4>
+        <input type="text" placeholder="例：平日20時以降" class="requirements-form--input-text"  />
+      </div>
+      <div class="requirements-form--column">
+        <h4 class="requirements-form--sub-title">Git・GitHubについて</h4>
+        <div class="requirements-form--text"><input type="radio" name="git" value="poor" id="poor" /><label for="poor">Git及びGitHubがわからない</label></div>
+        <div class="requirements-form--text"><input type="radio" name="git" value="good" id="good" /><label for="good">Git及びGitHubは使ったことはあるが、言語化は厳しい</label></div>
+        <div class="requirements-form--text"><input type="radio" name="git" value="great" id="great" /><label for="great">Git及びGitHubはだいたいわかっていて、人にも説明できる。</label></div>
+      </div>
+      <div class="requirements-form--column">
+        <h4 class="requirements-form--sub-title">開発経験について</h4>
+        <div class="requirements-form--text"><input type="radio" name="engineering" value="beginner" id="beginner" /><lavel for="beginner">開発経験なし</lavel></div>
+        <div class="requirements-form--text"><input type="radio" name="engineering" value="elementary" id="elementary" /><label for="elementary">開発経験あり（ハッカソン入門コースのみ・実務未経験）</label></div>
+        <div class="requirements-form--text"><input type="radio" name="engineering" value="intermediate" id="intermediate" /><label for="intermediate">実務経験1年未満</label></div>
+        <div class="requirements-form--text"><input type="radio" name="engineering" value="advanced" id="advanced" /><label for="advanced">実務経験1年以上</label></div>
+      </div>
+      <input type="submit" class="submit-button" value="提出" />
+    </form>
+  </div>
 {% endblock %}

--- a/app/templates/requirements/index.html
+++ b/app/templates/requirements/index.html
@@ -1,6 +1,6 @@
 {% extends 'base/base_user.html' %}
 {% block head %}
-  <title>テスト</title>
+  <title>要件一覧</title>
   {% load static %}
   <link rel="stylesheet" href="{% static 'css/components/header.css' %}" />
   <link rel="stylesheet" href="{% static 'css/requirements/index.css' %}" />


### PR DESCRIPTION
### 要件詳細画面の作成
- 作成画面は以下の通りになっています。
- 要件一覧画面のタイトルの変更もコミットに入れています。
<img width="2940" height="3224" alt="FireShot Capture 001 - 要件詳細 -  localhost" src="https://github.com/user-attachments/assets/b89f7098-96df-4331-a0cc-8e82c319abe5" />

### その他
- URLからmetaタグをとり、表示するJavaScriptの作業はバックエンドと結合後実装します。