### PR TITLE
履歴一覧・詳細ページの作成

### DIFF
--- a/app/static/css/history/detail.css
+++ b/app/static/css/history/detail.css
@@ -1,0 +1,51 @@
+.body--wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 2%;
+  margin-bottom: 152px;
+}
+
+.history-contents {
+  background-color: #ffffff;
+  border-radius: 20px;
+  width: 30%;
+  height: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  font-size: 20px;
+}
+
+.history-contents--title {
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.history--position__link {
+  color: #9AB292;
+  border-bottom: 2px solid #9AB292;
+}
+
+.history-contents--position {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 4px 0;
+  border-radius: 20px;
+}
+
+.history--position__green {
+  background-color: #51A243;
+  color: #ffffff;
+}
+
+.history--position__blue {
+  background-color: #0096FF;
+  color: #ffffff;
+}
+
+.history--position__red {
+  background-color: #EE6720;
+  color: #ffffff;
+}

--- a/app/static/css/history/index.css
+++ b/app/static/css/history/index.css
@@ -1,0 +1,118 @@
+.history-lists {
+  width: 100%;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.history-list {
+  width: 100%;
+  height: 200px;
+  background-color: #ffffff;
+  border-radius: 20px;
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 0 8px 0 rgba(87, 97, 83, 0.1);
+}
+
+.history-list--left {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.history-list--left__title {
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.history-list--left__stacks {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.history-list--left__stacks-title {
+  height: 152px;
+  box-sizing: border-box;
+  background-color: #51A243;
+  border-radius: 50vw;
+  padding: 12px 4px;
+  font-size: 20px;
+  color: #ffffff;
+  writing-mode: vertical-rl;
+  text-align: center;
+}
+
+.history-list--left__stacks-icons {
+  width: 400px;
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 8px;
+  column-gap: 4px;
+}
+
+.history-list--left__stacks-icon {
+  width: 52px;
+  height: 52px;
+  background-color: #51A243;
+}
+
+.history-list--right {
+  height: 100%;
+  display: flex;
+  gap: 12px;
+}
+
+.history-list--right__contents {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.history-list--right__contents-title {
+  font-size: 20px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.history-list--right__contents-border {
+  width: 100%;
+  height: 4px;
+  background-color: #51A243;
+}
+
+.history-list--right__contents-main {
+  height: 100%;
+  font-size: 24px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.history--position {
+  font-size: 20px;
+  border-radius: 20px;
+  padding: 4px 8px;
+}
+
+.history--position__green {
+  background-color: #51A243;
+  color: #ffffff;
+}
+
+.history--position__blue {
+  background-color: #0096FF;
+  color: #ffffff;
+}
+
+.history--position__red {
+  background-color: #EE6720;
+  color: #ffffff;
+}

--- a/app/templates/history/detail.html
+++ b/app/templates/history/detail.html
@@ -1,0 +1,33 @@
+{% extends 'base/base_user.html' %}
+{% block head %}
+  <title>要件一覧</title>
+  {% load static %}
+  <link rel="stylesheet" href="{% static 'css/components/header.css' %}" />
+  <link rel="stylesheet" href="{% static 'css/components/requirements_sheet.css' %}" />
+  <link rel="stylesheet" href="{% static 'css/history/detail.css' %}" />
+{% endblock %}
+{% block body %}
+  {% include 'components/header.html' %}
+  <div class="body--wrap">
+    {% include 'components/requirements_sheet.html' %}
+    <div class="history-contents">
+      <div>
+        <div class="history-contents--title">参加ポジション</div>
+        <div class="history-contents--position history--position__green">フロント</div>
+      </div>
+      <div>
+        <div class="history-contents--title">GitHubリンク</div>
+        <a class="history--position__link">{}</a>
+      </div>
+      <div>
+        <div class="history-contents--title">メンバー</div>
+        <ul>
+          <li>{}</li>
+          <li>{}</li>
+          <li>{}</li>
+          <li>{}</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/history/index.html
+++ b/app/templates/history/index.html
@@ -1,0 +1,140 @@
+{% extends 'base/base_user.html' %}
+{% block head %}
+  <title>履歴一覧</title>
+  {% load static %}
+  <link rel="stylesheet" href="{% static 'css/components/header.css' %}" />
+  <link rel="stylesheet" href="{% static 'css/history/index.css' %}" />
+{% endblock %}
+{% block body %}
+  {% include 'components/header.html' %}
+  <div class="body--wrap">
+    <ul class="history-lists">
+      <li class="history-list">
+        <div class="history-list--left">
+          <div class="history-list--left__title">{タイトル}</div>
+          <div class="history-list--left__stacks">
+            <div class="history-list--left__stacks-title">技 術</div>
+            <div class="history-list--left__stacks-icons">
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+            </div>
+          </div>
+        </div>
+        <div class="history-list--right">
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">難易度</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">○級</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">参加人数</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">○人</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">チーム</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">{}</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">ポジション</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">
+              <div class="history--position history--position__green">フロント</div>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="history-list">
+        <div class="history-list--left">
+          <div class="history-list--left__title">{タイトル}</div>
+          <div class="history-list--left__stacks">
+            <div class="history-list--left__stacks-title">技 術</div>
+            <div class="history-list--left__stacks-icons">
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+            </div>
+          </div>
+        </div>
+        <div class="history-list--right">
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">難易度</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">○級</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">参加人数</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">○人</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">チーム</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">{}</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">ポジション</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">
+              <div class="history--position history--position__blue">バック</div>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="history-list">
+        <div class="history-list--left">
+          <div class="history-list--left__title">{タイトル}</div>
+          <div class="history-list--left__stacks">
+            <div class="history-list--left__stacks-title">技 術</div>
+            <div class="history-list--left__stacks-icons">
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+              <div class="history-list--left__stacks-icon">{}</div>
+            </div>
+          </div>
+        </div>
+        <div class="history-list--right">
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">難易度</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">○級</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">参加人数</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">○人</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">チーム</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">{}</div>
+          </div>
+          <div class="history-list--right__contents">
+            <div class="history-list--right__contents-title">ポジション</div>
+            <div class="history-list--right__contents-border"></div>
+            <div class="history-list--right__contents-main">
+              <div class="history--position history--position__red">インフラ</div>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+{% endblock %}


### PR DESCRIPTION
### 作業内容
- 履歴ページの作成
- 下記添付画像のように実装しました

### その他
- {}はバックエンドからのデータが入力される予定です
- 詳細画面の{応募数}はバックエンドと結合後、{参加人数}になる予定です。

|一覧|詳細|
|---|---|
|<img width="2438" height="1752" alt="FireShot Capture 004 - 履歴一覧 -  localhost" src="https://github.com/user-attachments/assets/68bf4465-8d5f-4513-b346-15552da3dc29" />|<img width="2438" height="3224" alt="FireShot Capture 005 - 要件一覧 -  localhost" src="https://github.com/user-attachments/assets/04900759-d59e-4d1b-b0f3-0c0bfa4a054d" />|