### PR TITLE
要件定義後のページ移動

### DIFF
--- a/app/requirements/views.py
+++ b/app/requirements/views.py
@@ -59,7 +59,7 @@ class RequirementFormView(View):
                         title=title,
                         url=url,
                     )
-        return redirect('requirements:list')
+        return redirect('requirements:form')
 
 class RequirementsListView(View):
     def get(self,request):


### PR DESCRIPTION
管理者側が扱うページは、form.htmlだけだったので、
form.htmlで要件定義した後に、form.htmlに戻るようにしました。

Close #31 